### PR TITLE
Use the configured command timeout when executing stored procedures

### DIFF
--- a/EntityFrameworkExtras.EF7/DatabaseExtensions.cs
+++ b/EntityFrameworkExtras.EF7/DatabaseExtensions.cs
@@ -70,6 +70,11 @@ namespace EntityFrameworkExtras.EF7
             {
                 command.CommandText = query;
                 command.CommandType = CommandType.Text;
+                int? commandTimeout = database.GetCommandTimeout();
+                if (commandTimeout.HasValue)
+                {
+                    command.CommandTimeout = commandTimeout.Value;
+                }
                 command.Parameters.AddRange(parameters);
                 database.OpenConnection();
 


### PR DESCRIPTION
This allows the user to configure the override the command timeout for long running stored procedures.